### PR TITLE
fix: only methods decorated with AddStep are scene steps

### DIFF
--- a/lib/decorators/scene/add-step.decorator.ts
+++ b/lib/decorators/scene/add-step.decorator.ts
@@ -1,4 +1,4 @@
 import { SetMetadata } from '@nestjs/common';
 import { VK_SCENE_STEP_METADATA } from '../../vk.constants';
 
-export const AddStep = (step?: number) => SetMetadata<string>(VK_SCENE_STEP_METADATA, step);
+export const AddStep = (step?: number) => SetMetadata<string>(VK_SCENE_STEP_METADATA, step ?? true);

--- a/lib/services/listeners-explorer.service.ts
+++ b/lib/services/listeners-explorer.service.ts
@@ -157,8 +157,9 @@ export class ListenersExplorerService extends BaseExplorerService implements OnM
         }
         return;
       }
-      const step = this.metadataAccessor.getSceneStepMetadata(methodRef);
-      steps.push({ step: step ?? index++, methodName });
+      let step = this.metadataAccessor.getSceneStepMetadata(methodRef);
+      if (step === true) step = currentStep++;
+      if (Number.isInteger(step)) steps.push([step as number, method]);
     });
 
     const scene = new StepScene(sceneId, {

--- a/lib/services/metadata-accessor.service.ts
+++ b/lib/services/metadata-accessor.service.ts
@@ -31,7 +31,7 @@ export class MetadataAccessorService {
     return this.reflector.get(VK_SCENE_METADATA, target);
   }
 
-  getSceneStepMetadata(target: Function): number | undefined {
+  getSceneStepMetadata(target: Function): number | boolean | undefined {
     return this.reflector.get(VK_SCENE_STEP_METADATA, target);
   }
 


### PR DESCRIPTION
Сейчас, если создать сцену, то все методы внутри класса будут шагами сцены. Я думаю, что это неправильное поведение. К тому же, SceneEnter и SceneLeave не отрабатывают корректно и в целом ломают всё. Этот PR фиксит данное поведение.